### PR TITLE
Readme/tutorial cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,41 +4,37 @@
 #SLDS Sample Components
 SLDS Sample Components is an open-source project to provide a set of common Lightning Components that conform and wrap [Salesforce Lightning Design System's (SLDS)](http://getslds.com) CSS framework. This is to help you not worry about SLDS specific CSS, markup for basic components. And also to provide JS support so you don't have to implement them.
 
-
-Note: All components use `sldsx` namespace.
-
 ## Prerequisite:
 Needs Winter '16
 
-<image src="https://github.com/ForceDotComLabs/sldsx/blob/master/tutorial/images/winter16.png?raw=true" />
-
+![image](tutorial/images/winter16.png?)
 
 ## SLDSX Tutorial
 We've created a tutorial to explain how to use it. Please go through the <a href="https://github.com/ForceDotComLabs/sldsx/blob/master/tutorial-SLDSX/tutorial.md" target="_blank">tutorial here</a>.
+
 ![image](tutorial-SLDSX/accountsAppPic.png)
 
-####Installation
+#### Installation
 This project is distributed as an unmanaged package. The package has all the components, and latest version of SLDS framework (CSS, fonts, icons etc). To use it, simply install the package, load SLDS static resource and use individual components in your app.
 
 1. Install the [unmanaged package](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tB00000001mM1) (w/ SLDS v0.8).
 2. Load SLDS static resource
 
-	```    
-	<ltng:require styles="/resource/slds/assets/styles/salesforce-lightning-design-system-ltng.css"/>
+```xml
+<ltng:require styles="/resource/slds/assets/styles/salesforce-lightning-design-system-ltng.css"/>
+```
 
-	```
-	If your org has it's own namespace, for example: `ns` then, append `ns__` to the `sldsx` in the resource path to look like below:
+If your org has it's own namespace, for example: `ns` then, append `ns__` to the `sldsx` in the resource path to look like below:
 
-	```    
-	 <ltng:require styles="/resource/ns__slds/assets/styles/salesforce-lightning-design-system-ltng.css"/>
-
-	```
+```xml
+ <ltng:require styles="/resource/ns__slds/assets/styles/salesforce-lightning-design-system-ltng.css"/>
+```
 
 3. Write SLDS component under `<div class="slds">`
 
-        <div class="slds">
-                <c:button press="{!c.handlePress}" type="bare" iconCategory="utility" iconName="close" iconType="bare" iconSize="small"/>
-        </div>
+<div class="slds">
+        <c:button press="{!c.handlePress}" type="bare" iconCategory="utility" iconName="close" iconType="bare" iconSize="small"/>
+</div>
 
 Notes:
 If your org already has some of the components
@@ -49,8 +45,8 @@ SLDS app contains a list of all the SLDSX components and source code for each on
 Usage: Once you install the unmanaged package, open [{yourOrg}//{namespace}/SLDS.app](https://login.salesforce.com/c/SLDS.app).
 
 Note: All the components are in `metadata/aura/` folder.
-<image src="https://raw.githubusercontent.com/ForceDotComLabs/sldsx/master/slds-app-small.png?token=AAmOoX_EdgYwpP90hsQsIUFJ6zzW3R2Yks5V3LQ_wA%3D%3D"/>
 
+![image](slds-app-small.png)
 
 ## Distribution
 If you are distributing a component that's built using SLDSX, you need to package your component and SLDSX static resource. This is to ensure that your component uses proper version of SLDS.
@@ -59,7 +55,7 @@ If you are distributing a component that's built using SLDSX, you need to packag
 You can fork this repo and contribute newer SLDSX components or bug fixes. When you submit a new component, make sure it is in `metadata/aura` folder `metadata/aura/{yourcomponent}`
 In addition also provide an example usage of your component by editing `{yourOrg}//sldsx/SLDS.app` and adding your component at the bottom of the app.
 
-##License
+## License
 Please see the details in the `LICENSE` file above.
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ Note: All components use `sldsx` namespace.
 ## Prerequisite:
 Needs Winter '16
 
-<image src="tutorial/images/winter16.png" />
-
-
+<image src="https://github.com/ForceDotComLabs/sldsx/blob/master/tutorial/images/winter16.png?raw=true" />
 
 
 ## SLDSX Tutorial
@@ -22,24 +20,24 @@ We've created a tutorial to explain how to use it. Please go through the <a href
 ####Installation
 This project is distributed as an unmanaged package. The package has all the components, and latest version of SLDS framework (CSS, fonts, icons etc). To use it, simply install the package, load SLDS static resource and use individual components in your app.
 
-1. Install the [unmanaged package](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tB00000001mM1) (w/ SLDS v0.8). 
+1. Install the [unmanaged package](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tB00000001mM1) (w/ SLDS v0.8).
 2. Load SLDS static resource
 
 	```    
-	<ltng:require styles="/resource/sldsx/assets/styles/salesforce-lightning-design-system-vf.css"/>
+	<ltng:require styles="/resource/slds/assets/styles/salesforce-lightning-design-system-ltng.css"/>
 
 	```
 	If your org has it's own namespace, for example: `ns` then, append `ns__` to the `sldsx` in the resource path to look like below:
 
 	```    
-	 <ltng:require styles="/resource/ns__sldsx/assets/styles/salesforce-lightning-design-system-vf.css"/>
+	 <ltng:require styles="/resource/ns__slds/assets/styles/salesforce-lightning-design-system-ltng.css"/>
 
-	```	
+	```
 
-3. Write SLDS component under `<div class="slds">` 
+3. Write SLDS component under `<div class="slds">`
 
         <div class="slds">
-                <sldsx:button press="{!c.handlePress}" type="bare" iconCategory="utility" iconName="close" iconType="bare" iconSize="small"/>
+                <c:button press="{!c.handlePress}" type="bare" iconCategory="utility" iconName="close" iconType="bare" iconSize="small"/>
         </div>
 
 Notes:
@@ -54,18 +52,15 @@ Note: All the components are in `metadata/aura/` folder.
 <image src="https://raw.githubusercontent.com/ForceDotComLabs/sldsx/master/slds-app-small.png?token=AAmOoX_EdgYwpP90hsQsIUFJ6zzW3R2Yks5V3LQ_wA%3D%3D"/>
 
 
-
 ## Distribution
 If you are distributing a component that's built using SLDSX, you need to package your component and SLDSX static resource. This is to ensure that your component uses proper version of SLDS.
 
 ## Contribution
-You can fork this repo and contribute newer SLDSX components or bug fixes. When you submit a new component, make sure it is in `metadata/aura` folder `metadata/aura/{yourcomponent}` 
+You can fork this repo and contribute newer SLDSX components or bug fixes. When you submit a new component, make sure it is in `metadata/aura` folder `metadata/aura/{yourcomponent}`
 In addition also provide an example usage of your component by editing `{yourOrg}//sldsx/SLDS.app` and adding your component at the bottom of the app.
 
 ##License
 Please see the details in the `LICENSE` file above.
-
-
 
 ## Support
 This project is built as a 'labs' project and while a small team within Salesforce will try to maintain it, but it is so not officially supported.

--- a/tutorial-SLDSX/tutorial.md
+++ b/tutorial-SLDSX/tutorial.md
@@ -72,8 +72,7 @@ Lightning auto-generates documentation for all components based on the source co
 1. Open `{yourOrg}/auradocs/reference.app`
 2. Click on `Components > SLDSX` to see all the components in `SLDSX` namespace.
 
-
-<image src="auraDocsPic.png?token=AAmOoTO4_cqHfJtcvkz4oG5OiiBasPNBks5V3LlCwA%3D%3D"/>
+![image](auraDocsPic.png)
 
 # Part 2 - Building A Hello World App
 #### Step 1 - Load SLDS Framework
@@ -84,8 +83,9 @@ Lightning auto-generates documentation for all components based on the source co
 3. Find `SLDS.app`in the dialog
 4. Scroll through the source.
 
-Notice that the code loads SLDS as a static resource and also uses `slds` div parent element to CSS namespace the component so that CSS doesn't bleed into other components. This is how you load SLDS framework into your Lightning app or component.  
-<image src="sldsNSPic.png?token=AAmOoWs9vG13Omsxtqe5C_Zs3eTkWevAks5V3LlvwA%3D%3D"/>
+Notice that the code loads SLDS as a static resource and also uses `slds` div parent element to CSS namespace the component so that CSS doesn't bleed into other components. This is how you load SLDS framework into your Lightning app or component.
+
+![image](sldsNSPic.png?)
 
 Note: You don't need to load it in every component, you just need to load it in the main component or app that has all other components.
 
@@ -93,13 +93,12 @@ Note: You don't need to load it in every component, you just need to load it in 
 1. In Developer Console, Click on `New > Lightning Application`
 2. Enter `HelloSLDSX` and press `Submit`
 3. Add the following under `<Application>` tag to load SLDS framework and add a button.
-	```    
-	<ltng:require styles="/resource/sldsx__sds/assets/styles/salesforce-lightning-design-system-vf.css"/>
-	<div class="slds">
-      <c:button type="neutral">Button</c:button>
-    </div>
-
-	```
+```xml
+<ltng:require styles="/resource/sldsx__sds/assets/styles/salesforce-lightning-design-system-vf.css"/>
+<div class="slds">
+	<c:button type="neutral">Button</c:button>
+</div>
+```
 4. Press `Preview` and you'll see:
 
 	![image](buttonPic.png)
@@ -109,7 +108,8 @@ Note: You don't need to load it in every component, you just need to load it in 
 Every SLDSX components has multiple attributes that can have various values. Component look and feel changes based on attribute values.
 
 1. Let's change our button's `type` attribute to `brand`.
-	```
+
+	```xml
 	<c:button type="brand">Button</c:button>
 	```
 
@@ -125,19 +125,19 @@ Note: You can use  AuraDocs app (Step 3) to see list of attributes and possible 
 Every SLDSX component has a `press` attribute that allows us to add interact with press(button click) event in JavaScript controller.
 
 1. Add a `press="{!c.myButtonHandler}"` to our button.
-	```
+	```xml
 	<c:button press="{!c.myButtonHandler}" type="brand">Button</c:button>
 	```
 2. In Developer Console, click on `Controller` button on the right-side pane.
 2. Replace the code with the following:
 
-	```
+	```javascript
 	({
 		myButtonHandler : function(component, event, helper) {
 			alert('Button Clicked!');
 		}
 	})
-	```
+		```
 
 3. Click on the 'Preview' button or simply refresh browser.
 4. Click on the button
@@ -153,28 +153,29 @@ Grid system helps arrange the content in grids of 1 cell (container) upto 12 cel
 For example:
 If you want just 1 cell to occupy entire space, simply use: `1-of-1`.
 
-```
+```xml
 <c:grid  wrap="true">
- <c:col size="1-of-1">1-of-1</c:col>
+	<c:col size="1-of-1">1-of-1</c:col>
 </c:grid>
- ```
+```
+
 
 If you want just 1 cell to occupy 1/12 the space, simply use: `1-of-12`. This allows you to have 12 such cells in a single row.
 
-```
+```xml
 <c:grid  wrap="true">
-      <c:col size="1-of-12">1-of-12</c:col>
-            <c:col size="1-of-12">1-of-12</c:col>
-            <c:col size="1-of-12">1-of-12</c:col>
-            <c:col size="1-of-12">1-of-12</c:col>
-            <c:col size="1-of-12">1-of-12</c:col>
-            <c:col size="1-of-12">1-of-12</c:col>
-            <c:col size="1-of-12">1-of-12</c:col>
-            <c:col size="1-of-12">1-of-12</c:col>
-            <c:col size="1-of-12">1-of-12</c:col>
-            <c:col size="1-of-12">1-of-12</c:col>
-            <c:col size="1-of-12">1-of-12</c:col>
-            <c:col size="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-12">1-of-12</c:col>
 </c:grid>
 
 ```
@@ -208,26 +209,28 @@ In SLDSX components, they correspond to "size", "mdSize" and "lgSize" respective
 4. Squeeze the browser's width (not the height), you'll see that at certain point,it starts to show only 6 items per row and show the remaining 6 items in the 2nd row.
 5. Squeeze the browser's width (not the height) all the way to the smallest width. You'll see just 1 item per row and the remaining 11 items are displayed in different rows below.
 
-```
+```xml
 <c:grid  wrap="true">
-      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
-      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
-      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
-      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
-      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
-      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
-      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
-      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
-      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
-      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
-      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
-      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+  <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
 </c:grid>
 
 ```
 # Part 4 - Building An Accounts List App
 #### This app shows you how to use raw SLDS markup along with SLDSX components.
+
 ![image](accountsAppPic.png)
+
 SLDS framework provides a whole host of components that are not part of these sample components like: tables, headers and so on but we can use both togeather.
 In this example, we will build a simple Accounts app that shows list of accounts in a table.
 We'll use raw CSS instead of SLDSX components just to show that you can use it directly as well.
@@ -239,13 +242,15 @@ We'll use raw CSS instead of SLDSX components just to show that you can use it d
 2. Enter `AccountsController` as the name of the class.
 3. Paste the following code
 
-	```
+	```java
 	public class AccountsController {
-	  @AuraEnabled
-	  public static List<Account> getAccounts() {
-	    return [SELECT Id, name, industry, Type, NumberOfEmployees, TickerSymbol, Phone, BillingStreet, BillingCity, BillingState, BillingPostalCode
-	            FROM Account ORDER BY createdDate ASC];
-	  }   
+		@AuraEnabled
+		public static List<Account> getAccounts() {
+			return [SELECT Id, Name, Industry, Type, NumberOfEmployees,
+			TickerSymbol, Phone, BillingStreet, BillingCity,
+			BillingState, BillingPostalCode FROM Account ORDER BY
+			CreatedDate ASC];
+		}   
 	}
 	```
 4. Save it.
@@ -256,7 +261,7 @@ We'll use raw CSS instead of SLDSX components just to show that you can use it d
 2. Enter `AccountList` as the Bundle name
 3. Paste the following code:
 
-	```
+	```xml
 <aura:component controller="AccountsController">
 	  <aura:attribute name="accounts" type="List" />
 	  <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
@@ -295,13 +300,12 @@ We'll use raw CSS instead of SLDSX components just to show that you can use it d
 
 	In the above code, replace the following line:
 
-	```
+	```xml
 	<! !!! -- REPLACE THIS WITH A BUTTON COMPONENT !!!!! -->
 	```
 	With:
 
-
-	```
+	```xml
 	<c:button data="{!account.Id}" press="{!c.myButtonHandler}" type="brand">Details</c:button>
 	```
 
@@ -311,18 +315,19 @@ We'll use raw CSS instead of SLDSX components just to show that you can use it d
 1. While in AccountList component, click on the `Controller` menu in the right-side panel.
 2. Copy paste the below code:
 
-	```
+	```javascript
 	({
-		 doInit : function(component, event, helper) {      
+		doInit : function(component, event, helper) {      
 			//Fetch the expense list from the Apex controller   
-	        helper.getAccountList(component);
-	    },
-        myButtonHandler: function(component, event, helper) {
-            //Get data via "data-data" attribute
-            alert(event.target.getAttribute("data-data") + " was passed");
-        }
+			helper.getAccountList(component);
+		},
+		myButtonHandler: function(component, event, helper) {
+			//Get data via "data-data" attribute
+			alert(event.target.getAttribute("data-data") + " was passed");
+		}
 	})
 	```
+
 3. Save it
 
 #### Step 4 - Create JS Helper
@@ -331,10 +336,10 @@ Helper is used to interact with the server.
 1. While in AccountList component, click on the `Helper` menu in the right-side panel.
 2. Copy paste the below code:
 
-	```
+	```javascript
 	({
-	     //Fetch the accounts from the Apex controller
-	    getAccountList: function(component) {
+	  //Fetch the accounts from the Apex controller
+	  getAccountList: function(component) {
 	        var action = component.get("c.getAccounts");
 
 	        //Set up the callback
@@ -347,25 +352,25 @@ Helper is used to interact with the server.
 	})
 	```
 
+
 3. Save it.
 
 #### Step 5 - Update Hello SLDSX.app
 1. Open `HelloSLDSX.app`
 2. Copy-paste the code below:
 
-	```
+	```xml
 <aura:application >
-    <ltng:require styles="/resource/slds/assets/styles/salesforce-lightning-design-system-ltng.css"/>    
-    <div class="slds">
-        <br/>
-        <c:grid>     
-            <c:col>
-                <c:AccountList />
-            </c:col>    
-        </c:grid>   
-    </div>
+	<ltng:require styles="/resource/slds/assets/styles/salesforce-lightning-design-system-ltng.css"/>    
+	<div class="slds">
+		<br/>
+		<c:grid>     
+			<c:col>
+				<c:AccountList />
+			</c:col>    
+		</c:grid>   
+	</div>
 </aura:application>
-
 	```
 3. Save it.
 

--- a/tutorial-SLDSX/tutorial.md
+++ b/tutorial-SLDSX/tutorial.md
@@ -1,14 +1,14 @@
 <image src="https://raw.githubusercontent.com/ForceDotComLabs/sldsx/master/sflabs.png?token=AAmOoRHwmOYSLYk7FmSx_pBZfaG629e4ks5V3LsGwA%3D%3D"/>
 
-#SLDS Sample Components
+# SLDS Sample Components
 SLDS Sample Components is an open-source project to provide a set of common Lightning Components that conform and wrap [Salesforce Lightning Design System's (SLDS)](http://getslds.com) CSS framework. This is to help you not worry about SLDS specific CSS, markup for basic components. And also to provide JS support so you don't have to implement them.
 
 Note: These components are complementary to SLDS and not a replacement.
 
 This tutorial is created to help you learn how to use SLDS framework in custom Lightning Components and also how to use these sample components.  
 
-#Part 1 - Installation And Documentation
-####Step 1 - Enable Lightning Components
+# Part 1 - Installation And Documentation
+#### Step 1 - Enable Lightning Components
 
 1. Login to your Salesforce Org
 2. Go to `Setup > Develop > Lightning Components`
@@ -18,42 +18,42 @@ This tutorial is created to help you learn how to use SLDS framework in custom L
 	![image](enableLightningComponentsPic.png)
 
 4. **Register My Domain**
- 
+
 	In Winter '16 release, you may be asked to enable `My Domain` to use Lightning Components.
-	 
+
 	Follow the steps to enable it:
-	
+
 	4.1 Go to `Setup > Domain Management > My Domain`
-	
+
 	4.2 Enter a unique domain name (some string) and check for availability
-	
+
 	4.3 Agree to `Terms and Conditions`
-	
+
 	4.4 Press `Register`
-	
+
 	- You will get a notification when the registration is successful (It may take couple of minutes to 30 mins).
     - You then need to login with a new domain url, it may look like: `https://YOURDOMAIN-dev-ed.my.salesforce.com`
-    
+
     4.5  Go back to `Setup > Domain Management > My Domain`
-    
+
     4.6 Press `Push to users` button.
 
     ![image](myDomainPic.png)
 
-    > **Note:** It can take several minutes for the MyDomain feature to finish its provisioning process as it requires propagation of the new domain to Salesforce's DNS servers. You will be notified by email once the domain registration is complete. 
+    > **Note:** It can take several minutes for the MyDomain feature to finish its provisioning process as it requires propagation of the new domain to Salesforce's DNS servers. You will be notified by email once the domain registration is complete.
 
-    > For more information about the MyDomain feature see the [online help](https://help.salesforce.com/HTViewHelpDoc?id=faq_domain_name_what.htm&language=en_US) in your org. 
-    
+    > For more information about the MyDomain feature see the [online help](https://help.salesforce.com/HTViewHelpDoc?id=faq_domain_name_what.htm&language=en_US) in your org.
 
-####Step 2 - Installation
+
+#### Step 2 - Installation
 
 SLDSX is distributed as an [unmanaged package](https://help.salesforce.com/apex/HTViewHelpDoc?id=sharing_apps.htm&language=en). The package has all the components, and latest version of SLDS framework (CSS, fonts, icons etc). To use it, simply install the package, load SLDS static resource and use individual components in your app.
 
 1. Login to your Salesforce Org.
-2. Install the [unmanaged package](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tB00000001mM1)  (w/ SLDS v0.8). 
+2. Install the [unmanaged package](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tB00000001mM1)  (w/ SLDS v0.8).
 3. Keep the default settings and click `Install`.
 
-####Step 3 - Browse SLDS.app (Sample App)
+#### Step 3 - Browse SLDS.app (Sample App)
 SLDS app is a sample app that contains a list of all the SLDSX components and source code for each one of them. The examples are identical to what you'll find in the [Salesforce Lightning Design System's (SLDS)](http://salesforce-design-system.herokuapp.com) website.
 
 1. Open SLDS.app by changing the url to: [{yourOrg}//{namespace}/SLDS.app](https://login.salesforce.com/c/SLDS.app) or [https://login.salesforce.com/c/SLDS.app](https://login.salesforce.com/c/SLDS.app)
@@ -66,17 +66,17 @@ SLDS app is a sample app that contains a list of all the SLDSX components and so
 
 <image src="https://raw.githubusercontent.com/ForceDotComLabs/sldsx/master/slds-app-small.png?token=AAmOoekMbrdWQ43C9FIzvFNR2f616IVMks5V3LkjwA%3D%3D"/>
 
-####Step 4 - Browse SLDSX Docs
-Lightning auto-generates documentation for all components based on the source code. Since you installed the SLDSX components package, you'll be able to browse the docs for SLDSX components along with all other components! 
+#### Step 4 - Browse SLDSX Docs
+Lightning auto-generates documentation for all components based on the source code. Since you installed the SLDSX components package, you'll be able to browse the docs for SLDSX components along with all other components!
 
 1. Open `{yourOrg}/auradocs/reference.app`
-2. Click on `Components > SLDSX` to see all the components in `SLDSX` namespace. 
+2. Click on `Components > SLDSX` to see all the components in `SLDSX` namespace.
 
 
 <image src="auraDocsPic.png?token=AAmOoTO4_cqHfJtcvkz4oG5OiiBasPNBks5V3LlCwA%3D%3D"/>
 
-#Part 2 - Building A Hello World App
-####Step 1 - Load SLDS Framework
+# Part 2 - Building A Hello World App
+#### Step 1 - Load SLDS Framework
 `SLDS.app` itself uses a lot of SLDSX components, so you can simply see the source code to get an idea about how you can use various SLDSX components.
 
 1. Click on {Your Name} > Developer Console (on the top-right)
@@ -89,14 +89,14 @@ Notice that the code loads SLDS as a static resource and also uses `slds` div pa
 
 Note: You don't need to load it in every component, you just need to load it in the main component or app that has all other components.
 
-####Step 2 - Create a Standalone App
+#### Step 2 - Create a Standalone App
 1. In Developer Console, Click on `New > Lightning Application`
 2. Enter `HelloSLDSX` and press `Submit`
 3. Add the following under `<Application>` tag to load SLDS framework and add a button.
 	```    
 	<ltng:require styles="/resource/sldsx__sds/assets/styles/salesforce-lightning-design-system-vf.css"/>
 	<div class="slds">
-      <sldsx:button type="neutral">Button</sldsx:button>
+      <c:button type="neutral">Button</c:button>
     </div>
 
 	```
@@ -105,12 +105,12 @@ Note: You don't need to load it in every component, you just need to load it in 
 	![image](buttonPic.png)
 
 
-####Step 3 - Change An Attribute
-Every SLDSX components has multiple attributes that can have various values. Component look and feel changes based on attribute values. 
+#### Step 3 - Change An Attribute
+Every SLDSX components has multiple attributes that can have various values. Component look and feel changes based on attribute values.
 
 1. Let's change our button's `type` attribute to `brand`.
 	```
-	<sldsx:button type="brand">Button</sldsx:button>
+	<c:button type="brand">Button</c:button>
 	```
 
 4. Press 'Preview` and you'll see:
@@ -121,12 +121,12 @@ Note: You can use  AuraDocs app (Step 3) to see list of attributes and possible 
 
 
 
-####Step 4 - Add A JS Controller
-Every SLDSX component has a `press` attribute that allows us to add interact with press(button click) event in JavaScript controller. 
+#### Step 4 - Add A JS Controller
+Every SLDSX component has a `press` attribute that allows us to add interact with press(button click) event in JavaScript controller.
 
-1. Add a `press="{!c.myButtonHandler}"` to our button. 
+1. Add a `press="{!c.myButtonHandler}"` to our button.
 	```
-	<sldsx:button press="{!c.myButtonHandler}" type="brand">Button</sldsx:button>
+	<c:button press="{!c.myButtonHandler}" type="brand">Button</c:button>
 	```
 2. In Developer Console, click on `Controller` button on the right-side pane.
 2. Replace the code with the following:
@@ -138,56 +138,56 @@ Every SLDSX component has a `press` attribute that allows us to add interact wit
 		}
 	})
 	```
-	
+
 3. Click on the 'Preview' button or simply refresh browser.
 4. Click on the button
 5. You'll see `Button Clicked!` alert.
 
-#Part 3 - Building A Responsive App (Grid System)
+# Part 3 - Building A Responsive App (Grid System)
 An App is said to be responsive if it can adapt and display its contents irrespective of the screen size (i.e. viewed from a mobile, tablet or a laptop). Since the screens on the mobile devices are literally smaller than screens in laptops and large monitors, the app needs to automatically show or hide or rearrange the content depending on the screen size. To figure out how much data to show can be tricky and that's where the `Grid System` comes in handy.
 
-####Step 1 - Grid System
+#### Step 1 - Grid System
 
-####Sizes
-Grid system helps arrange the content in grids of 1 cell (container) upto 12 cells in a given row. You can specify how many cells you want in a row using `{cellSize}-of-{totalContainers}` format. 
-For example: 
+#### Sizes
+Grid system helps arrange the content in grids of 1 cell (container) upto 12 cells in a given row. You can specify how many cells you want in a row using `{cellSize}-of-{totalContainers}` format.
+For example:
 If you want just 1 cell to occupy entire space, simply use: `1-of-1`.
 
 ```
-<sldsx:grid  wrap="true">
- <sldsx:col size="1-of-1">1-of-1</sldsx:col>
-</sldsx:grid>
+<c:grid  wrap="true">
+ <c:col size="1-of-1">1-of-1</c:col>
+</c:grid>
  ```
- 
+
 If you want just 1 cell to occupy 1/12 the space, simply use: `1-of-12`. This allows you to have 12 such cells in a single row.
 
 ```
-<sldsx:grid  wrap="true">
-      <sldsx:col size="1-of-12">1-of-12</sldsx:col>
-            <sldsx:col size="1-of-12">1-of-12</sldsx:col>
-            <sldsx:col size="1-of-12">1-of-12</sldsx:col>
-            <sldsx:col size="1-of-12">1-of-12</sldsx:col>
-            <sldsx:col size="1-of-12">1-of-12</sldsx:col>
-            <sldsx:col size="1-of-12">1-of-12</sldsx:col>
-            <sldsx:col size="1-of-12">1-of-12</sldsx:col>
-            <sldsx:col size="1-of-12">1-of-12</sldsx:col>
-            <sldsx:col size="1-of-12">1-of-12</sldsx:col>
-            <sldsx:col size="1-of-12">1-of-12</sldsx:col>
-            <sldsx:col size="1-of-12">1-of-12</sldsx:col>
-            <sldsx:col size="1-of-12">1-of-12</sldsx:col>
-</sldsx:grid>
+<c:grid  wrap="true">
+      <c:col size="1-of-12">1-of-12</c:col>
+            <c:col size="1-of-12">1-of-12</c:col>
+            <c:col size="1-of-12">1-of-12</c:col>
+            <c:col size="1-of-12">1-of-12</c:col>
+            <c:col size="1-of-12">1-of-12</c:col>
+            <c:col size="1-of-12">1-of-12</c:col>
+            <c:col size="1-of-12">1-of-12</c:col>
+            <c:col size="1-of-12">1-of-12</c:col>
+            <c:col size="1-of-12">1-of-12</c:col>
+            <c:col size="1-of-12">1-of-12</c:col>
+            <c:col size="1-of-12">1-of-12</c:col>
+            <c:col size="1-of-12">1-of-12</c:col>
+</c:grid>
 
 ```
 
 ![image](gridSystemPic.png)
-	
+
 
 Note: Notice we are also using `wrap=true` attribute. This tells the Grid System to wrap and move the cell to the next row below if there are more cells than it can fit.
 
 ![image](wrapPic.png)
-	
-####Step 2 - Multiple Sizes For Various Screensizes
-In most apps you want to show different number of items depending on the screensize. 
+
+#### Step 2 - Multiple Sizes For Various Screensizes
+In most apps you want to show different number of items depending on the screensize.
 
 For example, if viewed from a mobile device you may want to show just one cell/item per row, but if viewed from a medium size screen like a tablet, you may want to show 6 cells/items in a single row. And finally if viewed from a large screen, you may want to show 12 cells/items in a single row.
 In Large Screen (e.g. laptops):
@@ -209,32 +209,32 @@ In SLDSX components, they correspond to "size", "mdSize" and "lgSize" respective
 5. Squeeze the browser's width (not the height) all the way to the smallest width. You'll see just 1 item per row and the remaining 11 items are displayed in different rows below.
 
 ```
-<sldsx:grid  wrap="true">
-      <sldsx:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</sldsx:col>
-      <sldsx:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</sldsx:col>
-      <sldsx:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</sldsx:col>
-      <sldsx:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</sldsx:col>
-      <sldsx:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</sldsx:col>
-      <sldsx:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</sldsx:col>
-      <sldsx:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</sldsx:col>
-      <sldsx:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</sldsx:col>
-      <sldsx:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</sldsx:col>
-      <sldsx:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</sldsx:col>
-      <sldsx:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</sldsx:col>
-      <sldsx:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</sldsx:col>
-</sldsx:grid>
+<c:grid  wrap="true">
+      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+      <c:col size="1-of-1" mdSize="1-of-6" lgSize="1-of-12">1-of-12</c:col>
+</c:grid>
 
 ```
-#Part 4 - Building An Accounts List App
-####This app shows you how to use raw SLDS markup along with SLDSX components.
+# Part 4 - Building An Accounts List App
+#### This app shows you how to use raw SLDS markup along with SLDSX components.
 ![image](accountsAppPic.png)
 SLDS framework provides a whole host of components that are not part of these sample components like: tables, headers and so on but we can use both togeather.
 In this example, we will build a simple Accounts app that shows list of accounts in a table.
-We'll use raw CSS instead of SLDSX components just to show that you can use it directly as well. 
+We'll use raw CSS instead of SLDSX components just to show that you can use it directly as well.
 
 
 
-####Step 1 - Create Accounts Apex Controller
+#### Step 1 - Create Accounts Apex Controller
 1. In Developer console, Click on New > Create Apex Class
 2. Enter `AccountsController` as the name of the class.
 3. Paste the following code
@@ -243,14 +243,14 @@ We'll use raw CSS instead of SLDSX components just to show that you can use it d
 	public class AccountsController {
 	  @AuraEnabled
 	  public static List<Account> getAccounts() {
-	    return [SELECT Id, name, industry, Type, NumberOfEmployees, TickerSymbol, Phone, BillingStreet, BillingCity, BillingState, BillingPostalCode 
+	    return [SELECT Id, name, industry, Type, NumberOfEmployees, TickerSymbol, Phone, BillingStreet, BillingCity, BillingState, BillingPostalCode
 	            FROM Account ORDER BY createdDate ASC];
 	  }   
 	}
 	```
 4. Save it.
 
-####Step 2 - Create AccountList Component
+#### Step 2 - Create AccountList Component
 
 1. In Developer console, Click on New > Lightning Components
 2. Enter `AccountList` as the Bundle name
@@ -294,23 +294,23 @@ We'll use raw CSS instead of SLDSX components just to show that you can use it d
 4. Add an SLDSX button that has JavaScript handler `{!c.myButtonHandler}` that also receives data via `data` attribute. The `data` attribute is useful to pass around data for example, to know exactly which Account button was clicked.
 
 	In the above code, replace the following line:
-	
+
 	```
 	<! !!! -- REPLACE THIS WITH A BUTTON COMPONENT !!!!! -->
 	```
 	With:
-	
-	
+
+
 	```
-	<sldsx:button data="{!account.Id}" press="{!c.myButtonHandler}" type="brand">Details</sldsx:button>
-	``` 
+	<c:button data="{!account.Id}" press="{!c.myButtonHandler}" type="brand">Details</c:button>
+	```
 
 5. Save
 
-####Step 3 - Create JS Controller
+#### Step 3 - Create JS Controller
 1. While in AccountList component, click on the `Controller` menu in the right-side panel.
 2. Copy paste the below code:
-	
+
 	```
 	({
 		 doInit : function(component, event, helper) {      
@@ -325,18 +325,18 @@ We'll use raw CSS instead of SLDSX components just to show that you can use it d
 	```
 3. Save it
 
-####Step 4 - Create JS Helper
+#### Step 4 - Create JS Helper
 Helper is used to interact with the server.
 
 1. While in AccountList component, click on the `Helper` menu in the right-side panel.
 2. Copy paste the below code:
-	
+
 	```
 	({
 	     //Fetch the accounts from the Apex controller
 	    getAccountList: function(component) {
 	        var action = component.get("c.getAccounts");
-	        
+
 	        //Set up the callback
 	        var self = this;
 	        action.setCallback(this, function(actionResult) {
@@ -349,23 +349,23 @@ Helper is used to interact with the server.
 
 3. Save it.
 
-####Step 5 - Update Hello SLDSX.app
+#### Step 5 - Update Hello SLDSX.app
 1. Open `HelloSLDSX.app`
 2. Copy-paste the code below:
-	
+
 	```
 <aura:application >
-    <ltng:require styles="/resource/sldsx__sds/assets/styles/salesforce-lightning-design-system-vf.css"/>    
+    <ltng:require styles="/resource/slds/assets/styles/salesforce-lightning-design-system-ltng.css"/>    
     <div class="slds">
         <br/>
-        <sldsx:grid>     
-            <sldsx:col>
-                <sldsx:AccountList />
-            </sldsx:col>    
-        </sldsx:grid>   
+        <c:grid>     
+            <c:col>
+                <c:AccountList />
+            </c:col>    
+        </c:grid>   
     </div>
 </aura:application>
-	
+
 	```
 3. Save it.
 
@@ -374,7 +374,7 @@ Helper is used to interact with the server.
 5. Press the `Details` button and you should see the Account Id in an alert box.
 ![image](accountsAppWithAccIdPic.png)
 
-#Summary
+# Summary
 Congratulations! You just learnt how to install SLDS framework, how to use the Sample components and also learnt how to use both SLDS framework and sample components togeather. From this point on, you can create your own SLDS component and use it in your Lightning projects.
 
 You can also contribute to the open-source project here: [https://github.com/ForceDotComLabs/sldsx](https://github.com/ForceDotComLabs/sldsx)

--- a/tutorial-SLDSX/tutorial.md
+++ b/tutorial-SLDSX/tutorial.md
@@ -379,6 +379,6 @@ Helper is used to interact with the server.
 ![image](accountsAppWithAccIdPic.png)
 
 # Summary
-Congratulations! You just learned how to install the SLDS framework, how to use the Sample components and also learnt how to use both SLDS framework and sample components togeather. From this point on, you can create your own SLDS component and use it in your Lightning projects.
+Congratulations! You just learned how to install the SLDS framework, how to use the Sample components and also learned how to use both SLDS framework and sample components togeather. From this point on, you can create your own SLDS component for use in your Lightning projects.
 
 You can also contribute to the open-source project here: [https://github.com/ForceDotComLabs/sldsx](https://github.com/ForceDotComLabs/sldsx)

--- a/tutorial-SLDSX/tutorial.md
+++ b/tutorial-SLDSX/tutorial.md
@@ -379,6 +379,6 @@ Helper is used to interact with the server.
 ![image](accountsAppWithAccIdPic.png)
 
 # Summary
-Congratulations! You just learnt how to install SLDS framework, how to use the Sample components and also learnt how to use both SLDS framework and sample components togeather. From this point on, you can create your own SLDS component and use it in your Lightning projects.
+Congratulations! You just learned how to install the SLDS framework, how to use the Sample components and also learnt how to use both SLDS framework and sample components togeather. From this point on, you can create your own SLDS component and use it in your Lightning projects.
 
 You can also contribute to the open-source project here: [https://github.com/ForceDotComLabs/sldsx](https://github.com/ForceDotComLabs/sldsx)

--- a/tutorial-SLDSX/tutorial.md
+++ b/tutorial-SLDSX/tutorial.md
@@ -137,7 +137,7 @@ Every SLDSX component has a `press` attribute that allows us to add interact wit
 			alert('Button Clicked!');
 		}
 	})
-		```
+	```
 
 3. Click on the 'Preview' button or simply refresh browser.
 4. Click on the button
@@ -246,10 +246,9 @@ We'll use raw CSS instead of SLDSX components just to show that you can use it d
 	public class AccountsController {
 		@AuraEnabled
 		public static List<Account> getAccounts() {
-			return [SELECT Id, Name, Industry, Type, NumberOfEmployees,
-			TickerSymbol, Phone, BillingStreet, BillingCity,
-			BillingState, BillingPostalCode FROM Account ORDER BY
-			CreatedDate ASC];
+			return [SELECT Id, Name, Industry, Type, NumberOfEmployees, TickerSymbol,
+			Phone, BillingStreet, BillingCity, BillingState, BillingPostalCode
+			FROM Account ORDER BY CreatedDate ASC];
 		}   
 	}
 	```


### PR DESCRIPTION
- To prevent confusion, changed up sections that indicated "sldsx" namespace was necessary for components instead of the default c: prefix
- Fixed broken images, other misc formatting items in the tutorial and main readme